### PR TITLE
Send IP information to admins after every switch

### DIFF
--- a/teamSwitch.cpp
+++ b/teamSwitch.cpp
@@ -131,6 +131,7 @@ bool switchPlayer(int index, std::string teamColor)
 
     addPlayer(playerData,index);
     sendPlayerInfo();
+    sendIPUpdate(-1, index);
 }
 
 bool bz_anyPlayers(bool observers = false)


### PR DESCRIPTION
This also fixes the bug where admins wouldn't get `player joined` messages after a switch.
