### PR TITLE
No need to cd to the directory of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This BZFlag plug-in has the capability of swapping players to a different team w
 Add this plug-in to the BZFlag build system and compile.
 
     sh newplug.sh teamSwitch
-    cd teamSwitch
     make
     sudo make install
 


### PR DESCRIPTION
If you try running `make` inside the directory of the teamSwitch plugin, you're just going to get an error, as you need to run autogen.sh and configure to create the required Makefiles. However, `make` performs the process automatically if you run it from the plugins directory.
